### PR TITLE
New rules, breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# changelog
+# Changelog
+
+## WIP
+
+* Breaking change: `@above` is no longer min-inclusive
+* Breaking change: `@below` is no longer max-inclusive
+* Breaking change: `@between` is no longer min/max-inclusive
+* New rules: `@from-width`, `@to-width`, `@between-from` and `@between-to`
 
 ## 0.1
 

--- a/README.md
+++ b/README.md
@@ -6,47 +6,55 @@
 
 Postcss plugin for easily create media queries. Inspired by [Rupture](https://github.com/jescalan/rupture) syntax.
 
-It makes available 4 at-rules:
-`@above`, `@between`, `@below` and `@breakpoint`:
+The plugin exposes the following media query at-rules:
+* `@above`
+* `@from-width` (min inclusive)
+* `@below`
+* `@to-width` (max inclusive)
+* `@between`
+* `@between-from` (min inclusive)
+* `@between-to` (max inclusive)
+
+And `@breakpoint` for defining a breakpoint.
+
+### Examples 
 
 ```css
-/* @media screen and (min-width: 768px) */
-@above 768px {
-  .box {
-    width: 25%;
-  }
-}
+@above 768px {}
+/* @media screen and (min-width: 769px) {} */
 
-/* @media screen and (min-width: 400px) and (max-width: 768px) */
-@between 400px 768px {
-  .box {
-    width: 50%;
-  }
-}
+@from-width 768px {}
+/* @media screen and (min-width: 768px) {} */
 
-/* @media screen and (max-width: 400px) */
-@below 400px {
-  .box {
-    width: 100%;
-  }
-}
+@below 400px {}
+/* @media screen and (max-width: 399px) {} */
+
+@to-width 400px {}
+/* @media screen and (max-width: 400px) {} */
+
+@between 400px 768px {}
+/* @media screen and (min-width: 401px) and (max-width: 767px) {} */
+
+@between-from 400px 768px {}
+/* @media screen and (min-width: 400px) and (max-width: 767px) {} */
+
+@between-to 400px 768px {}
+/* @media screen and (min-width: 400px) and (max-width: 768px) {} */
 ```
-
-You can also use `@breakpoint` to store breakpoints in variables:
 
 ```css
 @breakpoint md 768px;
 @breakpoint sm 400px;
 
 /* @media screen and (min-width: 768px) */
-@above md {
+@from-width md {
   .text {
     font-size: 2em;
   }
 }
 
-/* @media screen and (min-width: 400px) and (max-width: 768px) */
-@between sm md {
+/* @media screen and (min-width: 400px) and (max-width: 767px) */
+@between-from sm md {
   .text {
     font-size: 1.3em
   }

--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ function plugin (opts) {
   var breakpoints = opts.breakpoints || {}
 
   return function (root, result) {
-    root.walkAtRules(/(above|between|below|breakpoint)/, function (rule) {
+    root.walkAtRules(/(above|from-width|below|to-width|between(-(from|to))?$|breakpoint)/, function (rule) {
       if (rule.name === 'breakpoint') {
         storeBreakpoint(rule.params)
         return rule.remove()
       }
-      transformRule(rule)
+      rule.params = transformRule(rule.name, getMeasures(rule.params))
       rule.name = 'media'
     })
   }
@@ -22,31 +22,50 @@ function plugin (opts) {
     breakpoints[params[0]] = params[1]
   }
 
-  function transformRule (rule) {
-    var units = getUnits(rule.params)
+  function formatQuery (queryRules) {
+    return ['screen'].concat(queryRules).join(' and ')
+  }
 
-    rule.params = 'screen and '
-
-    if (rule.name === 'above') {
-      rule.params += '(min-width: ' + units[0] + ')'
-    }
-
-    if (rule.name === 'below') {
-      rule.params += '(max-width: ' + units[0] + ')'
-    }
-
-    if (rule.name === 'between') {
-      rule.params += '(min-width: ' + units[0] + ') and '
-      rule.params += '(max-width: ' + units[1] + ')'
+  function transformRule (name, measures) {
+    switch (name) {
+      case 'above':
+        return formatQuery(['(min-width: ' + (measures[0] + 1) + 'px)'])
+      case 'from-width':
+        return formatQuery(['(min-width: ' + measures[0] + 'px)'])
+      case 'below':
+        return formatQuery(['(max-width: ' + (measures[0] - 1) + 'px)'])
+      case 'to-width':
+        return formatQuery(['(max-width: ' + measures[0] + 'px)'])
+      case 'between':
+        return formatQuery([
+          '(min-width: ' + (measures[0] + 1) + 'px)',
+          '(max-width: ' + (measures[1] - 1) + 'px)'
+        ])
+      case 'between-from':
+        return formatQuery([
+          '(min-width: ' + measures[0] + 'px)',
+          '(max-width: ' + (measures[1] - 1) + 'px)'
+        ])
+      case 'between-to':
+        return formatQuery([
+          '(min-width: ' + (measures[0] + 1) + 'px)',
+          '(max-width: ' + measures[1] + 'px)'
+        ])
     }
   }
 
-  function getUnits (params) {
+  function parseBreakpointUnit (unit) {
+    return typeof unit === 'string'
+      ? parseInt(unit.replace('px', ''))
+      : unit
+  }
+
+  function getMeasures (params) {
     return params.split(/\s/).map(function (param) {
       if (breakpoints.hasOwnProperty(param)) {
-        return breakpoints[param]
+        return parseBreakpointUnit(breakpoints[param])
       }
-      return param
+      return parseBreakpointUnit(param)
     })
   }
 }

--- a/test/expected/below.css
+++ b/test/expected/below.css
@@ -1,4 +1,4 @@
-@media screen and (max-width: 1280px) {
+@media screen and (max-width: 1279px) {
   .test {
     color: blue;
   }

--- a/test/expected/between-from.css
+++ b/test/expected/between-from.css
@@ -1,0 +1,5 @@
+@media screen and (min-width: 400px) and (max-width: 599px) {
+  .box {
+    background-color: blue;
+  }
+}

--- a/test/expected/between-to.css
+++ b/test/expected/between-to.css
@@ -1,0 +1,5 @@
+@media screen and (min-width: 401px) and (max-width: 600px) {
+  .box {
+    background-color: blue;
+  }
+}

--- a/test/expected/between.css
+++ b/test/expected/between.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 400px) and (max-width: 600px) {
+@media screen and (min-width: 401px) and (max-width: 599px) {
   .my-box {
     width: 100%;
   }

--- a/test/expected/breakpoint.css
+++ b/test/expected/breakpoint.css
@@ -1,11 +1,11 @@
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 769px) {
   .element {
     display: inline-block;
     margin: 15px;
   }
 }
 
-@media screen and (min-width: 400px) and (max-width: 768px) {
+@media screen and (min-width: 401px) and (max-width: 767px) {
   .element {
     display: block;
     margin: 5px;
@@ -13,7 +13,7 @@
   }
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (max-width: 399px) {
   .element {
     display: none;
   }

--- a/test/expected/breakpoints-from-opts.css
+++ b/test/expected/breakpoints-from-opts.css
@@ -1,10 +1,16 @@
-@media screen and (min-width: 800px) {
+@media screen and (min-width: 801px) {
   .element {
     color: #fff;
   }
 }
 
-@media screen and (min-width: 600px) and (max-width: 800px) {
+@media screen and (max-width: 799px) {
+  .element {
+    color: #0f0;
+  }
+}
+
+@media screen and (min-width: 601px) and (max-width: 799px) {
   .element {
     color: #000;
   }

--- a/test/expected/from-width.css
+++ b/test/expected/from-width.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 701px) {
+@media screen and (min-width: 700px) {
   .box {
     background-color: blue;
   }

--- a/test/expected/to-width.css
+++ b/test/expected/to-width.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 701px) {
+@media screen and (max-width: 700px) {
   .box {
     background-color: blue;
   }

--- a/test/source/between-from.css
+++ b/test/source/between-from.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 701px) {
+@between-from 400px 600px {
   .box {
     background-color: blue;
   }

--- a/test/source/between-to.css
+++ b/test/source/between-to.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 701px) {
+@between-to 400px 600px {
   .box {
     background-color: blue;
   }

--- a/test/source/breakpoints-from-opts.css
+++ b/test/source/breakpoints-from-opts.css
@@ -4,6 +4,12 @@
   }
 }
 
+@below tablet {
+  .element {
+    color: #0f0;
+  }
+}
+
 @between mobile tablet {
   .element {
     color: #000;

--- a/test/source/from-width.css
+++ b/test/source/from-width.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 701px) {
+@from-width 700px {
   .box {
     background-color: blue;
   }

--- a/test/source/to-width.css
+++ b/test/source/to-width.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 701px) {
+@to-width 700px {
   .box {
     background-color: blue;
   }


### PR DESCRIPTION
### Changes

* Breaking change: `@above` is no longer min-inclusive
* Breaking change: `@below` is no longer max-inclusive
* Breaking change: `@between` is no longer min/max-inclusive
* Introduced new rules: `@from-width`, `@to-width`, `@between-from` and `@between-to`
* Breakpoint values in config can now be written in ints as well as in strings (valid values: `700`, `'700px'`, `'700'`)

### Reasoning
According to common terminology, "above", "below", "between" should not be inclusive. Also, media queries are usually used in pairs so that one of the queries excludes the break point. Added rules are named after the ones in the Rupture library.

### Note
Please bump the version to 1.x.x as some of the changes are breaking.